### PR TITLE
fix bad Future code generated for java primitive return values

### DIFF
--- a/oncrpc4j-rpcgen/src/main/java/org/acplt/oncrpc/apps/jrpcgen/jrpcgen.java
+++ b/oncrpc4j-rpcgen/src/main/java/org/acplt/oncrpc/apps/jrpcgen/jrpcgen.java
@@ -30,12 +30,8 @@ package org.acplt.oncrpc.apps.jrpcgen;
 import org.acplt.oncrpc.apps.jrpcgen.cup_runtime.Symbol;
 
 import java.io.*;
-import java.util.Enumeration;
-import java.util.Date;
+import java.util.*;
 import java.text.SimpleDateFormat;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * The class <code>jrpcgen</code> implements a Java-based rpcgen RPC protocol
@@ -520,8 +516,11 @@ public class jrpcgen {
         "void",
         "boolean",
         "byte",
-        "short", "int", "long",
-        "float", "double",
+        "short",
+        "int",
+        "long",
+        "float",
+        "double",
         "String"
     };
 
@@ -837,6 +836,22 @@ public class jrpcgen {
             return "byte";
         }
         return dataType;
+    }
+
+    /**
+     * given a java type, return the XdrAble wrapper for it.
+     * this applies mostly to java primitives and immutables
+     * (like int and String respectively)
+     * otherwise return the original (assumed to be XdrAble)
+     * @param javaType a java type (ex "int")
+     * @return the boxed, XdrAble type, or the argument, if none required
+     */
+    public static String boxForTransport(String javaType) {
+        String xdrWrapper = xdrBaseType(javaType);
+        if (xdrWrapper != null) {
+            return xdrWrapper;
+        }
+        return javaType;
     }
 
     /**
@@ -1491,7 +1506,7 @@ public class jrpcgen {
                 methodName = proc.procedureId;
                 break;
             case FUTURE:
-                returnType = "Future<"+resultType+">";
+                returnType = "Future<"+ boxForTransport(resultType)+">";
                 methodName = proc.procedureId+"_future";
                 break;
             case CALLBACK:
@@ -1699,7 +1714,7 @@ public class jrpcgen {
             case FUTURE:
                 out.println("        return client.call("
                         + baseClassname + "." + proc.procedureId
-                        + ", " + xdrParamsName + ", " + resultType + ".class);");
+                        + ", " + xdrParamsName + ", " + boxForTransport(resultType) + ".class);");
                 break;
             case CALLBACK:
             case ONE_WAY:

--- a/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/CalculatorServerImpl.java
+++ b/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/CalculatorServerImpl.java
@@ -20,6 +20,11 @@ public class CalculatorServerImpl extends CalculatorServer {
 
     @Override
     public long addSimple_1(RpcCall call$, long arg1, long arg2) {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
         return arg1 + arg2;
     }
 }

--- a/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/CalculatorServerImpl.java
+++ b/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/CalculatorServerImpl.java
@@ -17,4 +17,9 @@ public class CalculatorServerImpl extends CalculatorServer {
         result.setFinishMillis(System.currentTimeMillis());
         return result;
     }
+
+    @Override
+    public long addSimple_1(RpcCall call$, long arg1, long arg2) {
+        return arg1 + arg2;
+    }
 }

--- a/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/FutureCalculatorTest.java
+++ b/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/FutureCalculatorTest.java
@@ -69,6 +69,9 @@ public class FutureCalculatorTest {
         Assert.assertNotNull(result);
         Assert.assertEquals(3, result.longValue());
         //not really proof of async, but good enough?
+        //the condition below is a bit fragile and relies on the fact
+        //that there's a 10-milli sleep server side and the invocation
+        //is likely to take much less
         Assert.assertTrue(waitTime > invocationTime);
     }
 }

--- a/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/FutureCalculatorTest.java
+++ b/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/FutureCalculatorTest.java
@@ -1,9 +1,6 @@
 package org.dcache.oncrpc4j.rpcgen;
 
-import org.dcache.xdr.IpProtocolType;
-import org.dcache.xdr.OncRpcProgram;
-import org.dcache.xdr.OncRpcSvc;
-import org.dcache.xdr.OncRpcSvcBuilder;
+import org.dcache.xdr.*;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,5 +55,20 @@ public class FutureCalculatorTest {
         Assert.assertTrue(result.startMillis < result.finishMillis);
         Assert.assertTrue(result.finishMillis <= resTime);
         Assert.assertTrue(retTime < result.finishMillis);
+    }
+
+    @Test
+    public void testFutureAddSimple() throws Exception {
+        long callTime = System.nanoTime();
+        Future<XdrLong> future = client.addSimple_1_future(1, 2);
+        long retTime = System.nanoTime();
+        XdrLong result = future.get();
+        long resTime = System.nanoTime();
+        long invocationTime = retTime-callTime;
+        long waitTime = resTime-retTime;
+        Assert.assertNotNull(result);
+        Assert.assertEquals(3, result.longValue());
+        //not really proof of async, but good enough?
+        Assert.assertTrue(waitTime > invocationTime);
     }
 }

--- a/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/SyncCalculatorTest.java
+++ b/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/SyncCalculatorTest.java
@@ -47,4 +47,9 @@ public class SyncCalculatorTest {
         Assert.assertNotNull(result);
         Assert.assertEquals(3, result.getResult());
     }
+
+    @Test
+    public void testSyncAddSimple() throws Exception {
+        Assert.assertEquals(3, client.addSimple_1(1, 2));
+    }
 }

--- a/oncrpc4j-rpcgen/src/test/xdr/Calculator.x
+++ b/oncrpc4j-rpcgen/src/test/xdr/Calculator.x
@@ -7,5 +7,6 @@ struct CalculationResult {
 program CALCULATOR {
     version CALCULATORVERS {
         CalculationResult add(hyper, hyper) = 1;
+        hyper addSimple(hyper, hyper) = 2;
     } = 1;
 } = 117;

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,16 @@
           <artifactId>maven-pmd-plugin</artifactId>
           <version>3.0.1</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.4.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>1.9.1</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
dont generate things like Future<int>
note, however, that this brings up an issue with primitive/immutable return types - we're forced to expose the underlying XdrAble wrapper - so we noe generate methods that return Future<XdrLong> instead of Future<Long>. 