### PR TITLE
make sure that oneway calls do not fail silently if connection was dropped

### DIFF
--- a/oncrpc4j-core/src/main/java/org/dcache/xdr/ReplyQueue.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/xdr/ReplyQueue.java
@@ -47,6 +47,12 @@ public class ReplyQueue {
     private final Map<Integer, HandlerTimeoutPair> _queue = new HashMap<>();
     private boolean _isConnected = true;
 
+    public void assertConnected() throws EOFException {
+        if (!_isConnected) {
+            throw new EOFException("Disconnected");
+        }
+    }
+
     /**
      * Creates a placeholder for the specified key, and no timeout
      *

--- a/oncrpc4j-core/src/main/java/org/dcache/xdr/RpcCall.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/xdr/RpcCall.java
@@ -349,8 +349,12 @@ public class RpcCall {
         args.xdrEncode(xdr);
         xdr.endEncoding();
 
+        ReplyQueue replyQueue = _transport.getReplyQueue();
         if (callback != null) {
-            _transport.getReplyQueue().registerKey(xid, callback, timeoutValue, timeoutUnits);
+            replyQueue.registerKey(xid, callback, timeoutValue, timeoutUnits);
+        } else {
+            //no handler, so we wont get any errors if connection was dropped. have to check.
+            replyQueue.assertConnected(); //EOFException if not
         }
         _transport.send(xdr);
         return xid;

--- a/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/CalculatorServerImpl.java
+++ b/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/CalculatorServerImpl.java
@@ -22,21 +22,30 @@ public class CalculatorServerImpl extends CalculatorServer {
         }
         long finish = System.currentTimeMillis();
         result.setFinishMillis(finish);
-        Object[] args = new Object[2];
-        args[0] = arg1;
-        args[1] = arg2;
-        methodCalls.add(new MethodCall(start, finish, Thread.currentThread().getStackTrace()[0].getMethodName(), args, result.getResult(), null));
+        recordAddCall(start, finish, arg1, arg2, result.getResult(), null);
         return result;
     }
 
     @Override
     public long addSimple_1(RpcCall call$, long arg1, long arg2) {
+        long start = System.currentTimeMillis();
         try {
             Thread.sleep(SLEEP_MILLIS);
         } catch (InterruptedException e) {
             //ignore
         }
-        return arg1 + arg2;
+        long result = arg1 + arg2;
+        long finish = System.currentTimeMillis();
+        recordAddCall(start, finish, arg1, arg2, result, null);
+        return result;
+    }
+
+    private void recordAddCall(long start, long finish, long arg1, long arg2, long result, Throwable throwable) {
+        System.err.println(arg1 + " + " + arg2 + " = " + result);
+        Object[] args = new Object[2];
+        args[0] = arg1;
+        args[1] = arg2;
+        methodCalls.add(new MethodCall(start, finish, Thread.currentThread().getStackTrace()[1].getMethodName(), args, result, throwable));
     }
 
     public List<MethodCall> getMethodCalls() {

--- a/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/OnewayCalculatorTest.java
+++ b/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/OnewayCalculatorTest.java
@@ -3,6 +3,7 @@ package org.dcache.oncrpc4j.rpcgen;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.EOFException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -21,5 +22,19 @@ public class OnewayCalculatorTest extends AbstractCalculatorTest {
         MethodCall call = calls.get(0);
         Assert.assertEquals(3L, call.getReturnValue());
         Assert.assertTrue(retTime < call.getFinishTimestamp());
+    }
+
+    @Test
+    public void testDisconnection() throws Exception {
+        client.add_1_oneway(1, 2);
+        Thread.sleep(100);
+        server.stop();
+        Thread.sleep(100);
+        try {
+            client.add_1_oneway(1, 2);
+            Assert.fail("should have thrown an exception");
+        } catch (EOFException e) {
+            //expected
+        }
     }
 }


### PR DESCRIPTION
oneway calls do not register anything with the reply queue.
the reply queue is the component that is notified of disconnections (it registers with grizzly).
this leads to a situation where the connection was closed, yet oneway calls do not throw anything.
this patch makes oneway calls verify the connection is still open (by asking the reply queue).

test attached.