### PR TITLE
upgrade guava to 18.0 to match jpnfs

### DIFF
--- a/oncrpc4j-core/src/main/java/org/dcache/xdr/ReplyQueue.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/xdr/ReplyQueue.java
@@ -19,7 +19,6 @@
  */
 package org.dcache.xdr;
 
-import javax.annotation.Nonnull;
 import java.io.EOFException;
 import java.nio.channels.CompletionHandler;
 import java.util.HashMap;
@@ -38,7 +37,7 @@ public class ReplyQueue {
         private final AtomicInteger counter = new AtomicInteger();
 
         @Override
-        public Thread newThread(@Nonnull Runnable r) {
+        public Thread newThread(Runnable r) {
             Thread t = new Thread(r, "timeout thread #" + counter.incrementAndGet() + " for ReplyQueue " + ReplyQueue.this);
             t.setDaemon(true);
             return t;

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
           <dependency>
               <groupId>com.google.guava</groupId>
               <artifactId>guava</artifactId>
-              <version>10.0.1</version>
+              <version>18.0</version>
           </dependency>
           <dependency>
               <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
this is needed because right now the dependency tree for projects using both oncrpc4j and jpnfs looks like this:

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ simple-nfs-client ---
[INFO] net.radai:simple-nfs-client:jar:1.0-SNAPSHOT
[INFO] +- org.dcache:oncrpc4j-core:jar:2.5.0-SNAPSHOT:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.5:compile
[INFO] |  +- org.glassfish.grizzly:grizzly-framework:jar:2.3.12:compile
[INFO] |  +- org.dcache.common:dcache-auth:jar:0.0.11:compile
[INFO] |  +- com.google.guava:guava:jar:10.0.1:compile
[INFO] |  |  \- com.google.code.findbugs:jsr305:jar:1.3.9:compile
[INFO] |  \- org.glassfish.gmbal:gmbal-api-only:jar:3.2.0-b003:compile
[INFO] |     \- org.glassfish.external:management-api:jar:3.0.0-b012:compile
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] \- org.dcache:simple-nfs:jar:1.0-SNAPSHOT:test
[INFO]    +- org.dcache:nfs4j-core:jar:0.11.0-SNAPSHOT:test
[INFO]    |  +- jline:jline:jar:2.12.1:test
[INFO]    |  +- org.dcache.chimera:chimera-core:jar:0.0.15-SNAPSHOT:test
[INFO]    |  |  \- org.liquibase:liquibase-core:jar:3.3.2:test
[INFO]    |  \- org.glassfish.gmbal:gmbal:jar:3.2.0-b003:test
[INFO]    |     +- org.glassfish.pfl:pfl-basic:jar:1.0.0-b001:test
[INFO]    |     +- org.glassfish.pfl:pfl-tf:jar:1.0.0-b001:test
[INFO]    |     |  \- org.glassfish.pfl:pfl-asm:jar:1.0.0-b001:test
[INFO]    |     +- org.glassfish.pfl:pfl-tf-tools:jar:1.0.0-b001:test
[INFO]    |     \- org.glassfish.pfl:pfl-basic-tools:jar:1.0.0-b001:test
[INFO]    +- org.slf4j:log4j-over-slf4j:jar:1.7.7:test
[INFO]    +- ch.qos.logback:logback-classic:jar:1.1.2:test
[INFO]    |  \- ch.qos.logback:logback-core:jar:1.1.2:test
[INFO]    +- args4j:args4j:jar:2.0.29:test
[INFO]    \- com.boundary:high-scale-lib:jar:1.0.6:test
```

note that oncrpc4j pulls in guava 10.0.1

when combined with jpnfs (specifically class org.dcache.nfs.FsExport) this leads to runtime exceptions like this:

```
java.lang.NoSuchMethodError: com.google.common.io.Files.simplifyPath(Ljava/lang/String;)Ljava/lang/String;
	at org.dcache.nfs.FsExport.normalize(FsExport.java:232)
	at org.dcache.nfs.FsExport.<init>(FsExport.java:109)
	at org.dcache.nfs.FsExport.<init>(FsExport.java:31)
	at org.dcache.nfs.FsExport$FsExportBuilder.build(FsExport.java:376)
	at org.dcache.nfs.ExportFile.parse(ExportFile.java:212)
	at org.dcache.nfs.ExportFile.parse(ExportFile.java:74)
	at org.dcache.nfs.ExportFile.<init>(ExportFile.java:62)
	at org.dcache.simplenfs.SimpleNfsServer.<init>(SimpleNfsServer.java:36)
```

because FsExport is compiled against guava 18.0

this commit makes the versions match (and removed a dependency on Nonnull, which was packaged with earlier guava versions)