### PR TITLE
allow setting service name on OncRpcSvc (affects thread names)

### DIFF
--- a/oncrpc4j-core/src/main/java/org/dcache/xdr/GrizzlyUtils.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/xdr/GrizzlyUtils.java
@@ -71,48 +71,54 @@ public class GrizzlyUtils {
     }
 
     static private int getSelectorPoolSize(IoStrategy ioStrategy) {
-	return ioStrategy == WORKER_THREAD
-		? Math.max(MIN_SELECTORS, CPUS / 4) : Math.max(MIN_WORKERS, CPUS);
+        return ioStrategy == WORKER_THREAD
+                ? Math.max(MIN_SELECTORS, CPUS / 4) : Math.max(MIN_WORKERS, CPUS);
     }
 
     static private int getWorkerPoolSize(IoStrategy ioStrategy) {
-	return ioStrategy == WORKER_THREAD
-		? Math.max(MIN_WORKERS, (CPUS * 2)) : 0;
+        return ioStrategy == WORKER_THREAD
+                ? Math.max(MIN_WORKERS, (CPUS * 2)) : 0;
     }
 
     /**
      * Pre-configure Selectors thread pool for given {@link IOStrategy}
      *
-     * @param ioStrategy in use
+     * @param ioStrategy to use
+     * @param serviceName service name (affects thread names)
      * @return thread pool configuration.
      */
-    static ThreadPoolConfig getSelectorPoolCfg(OncRpcSvc.IoStrategy ioStrategy) {
-	final int poolSize = getSelectorPoolSize(ioStrategy);
-	final ThreadPoolConfig poolCfg = ThreadPoolConfig.defaultConfig();
-	poolCfg.setCorePoolSize(poolSize).setMaxPoolSize(poolSize);
-	poolCfg.setPoolName("OncRpcSvc"); // grizzly will add "SelectorRunner"
+    static ThreadPoolConfig getSelectorPoolCfg(IoStrategy ioStrategy, String serviceName) {
+        final int poolSize = getSelectorPoolSize(ioStrategy);
+        final ThreadPoolConfig poolCfg = ThreadPoolConfig.defaultConfig();
+        poolCfg.setCorePoolSize(poolSize).setMaxPoolSize(poolSize);
+        if (serviceName != null) {
+            poolCfg.setPoolName(serviceName); //grizzly will add "SelectorRunner"
+        }
 
-	return poolCfg;
+        return poolCfg;
     }
 
     /**
      * Pre-configure Worker thread pool for given {@link IOStrategy}
      *
      * @param ioStrategy in use
+     * @param serviceName service name (affects thread names)
      * @return thread pool configuration or {@code null}, if ioStrategy don't
      * supports worker threads.
      */
-    static ThreadPoolConfig getWorkerPoolCfg(OncRpcSvc.IoStrategy ioStrategy) {
+    static ThreadPoolConfig getWorkerPoolCfg(IoStrategy ioStrategy, String serviceName) {
 
-	if (ioStrategy == SAME_THREAD) {
-	    return null;
-	}
+        if (ioStrategy == SAME_THREAD) {
+            return null;
+        }
 
-	final int poolSize = getWorkerPoolSize(ioStrategy);
-	final ThreadPoolConfig poolCfg = ThreadPoolConfig.defaultConfig();
-	poolCfg.setCorePoolSize(poolSize).setMaxPoolSize(poolSize);
-	poolCfg.setPoolName("OncRpcSvc Worker");
+        final int poolSize = getWorkerPoolSize(ioStrategy);
+        final ThreadPoolConfig poolCfg = ThreadPoolConfig.defaultConfig();
+        poolCfg.setCorePoolSize(poolSize).setMaxPoolSize(poolSize);
+        if (serviceName != null) {
+            poolCfg.setPoolName(serviceName + " Worker");
+        }
 
-	return poolCfg;
+        return poolCfg;
     }
 }

--- a/oncrpc4j-core/src/main/java/org/dcache/xdr/OncRpcSvc.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/xdr/OncRpcSvc.java
@@ -107,7 +107,8 @@ public class OncRpcSvc {
         }
 
         IoStrategy ioStrategy = builder.getIoStrategy();
-        ThreadPoolConfig selectorPoolConfig = getSelectorPoolCfg(ioStrategy);
+        String serviceName = builder.getServiceName();
+        ThreadPoolConfig selectorPoolConfig = getSelectorPoolCfg(ioStrategy, serviceName);
 
         if ((protocol & IpProtocolType.TCP) != 0) {
             final TCPNIOTransport tcpTransport = TCPNIOTransportBuilder

--- a/oncrpc4j-core/src/main/java/org/dcache/xdr/OncRpcSvcBuilder.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/xdr/OncRpcSvcBuilder.java
@@ -20,12 +20,13 @@
 package org.dcache.xdr;
 
 import com.google.common.util.concurrent.MoreExecutors;
-import java.util.concurrent.ExecutorService;
 import org.dcache.xdr.gss.GssSessionManager;
 import org.glassfish.grizzly.threadpool.FixedThreadPool;
 import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
 
-import static com.google.common.base.Preconditions.*;
+import java.util.concurrent.ExecutorService;
+
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.dcache.xdr.GrizzlyUtils.getWorkerPoolCfg;
 
 
@@ -60,6 +61,7 @@ public class OncRpcSvcBuilder {
     private boolean _withJMX = false;
     private int _backlog = 4096;
     private String _bindAddress = "0.0.0.0";
+    private String _serviceName = "OncRpcSvc";
     private GssSessionManager _gssSessionManager;
     private ExecutorService _workerThreadExecutionService;
 
@@ -128,6 +130,11 @@ public class OncRpcSvcBuilder {
         return this;
     }
 
+    public OncRpcSvcBuilder withServiceName(String serviceName) {
+        _serviceName = serviceName;
+        return this;
+    }
+
     public OncRpcSvcBuilder withGssSessionManager(GssSessionManager gssSessionManager) {
         _gssSessionManager = gssSessionManager;
         return this;
@@ -170,20 +177,24 @@ public class OncRpcSvcBuilder {
         return _bindAddress;
     }
 
+    public String getServiceName() {
+        return _serviceName;
+    }
+
     public GssSessionManager getGssSessionManager() {
         return _gssSessionManager;
     }
 
     public ExecutorService getWorkerThreadExecutorService() {
         if (_ioStrategy == OncRpcSvc.IoStrategy.SAME_THREAD ) {
-            return MoreExecutors.sameThreadExecutor();
+            return MoreExecutors.newDirectExecutorService();
         }
 
         if (_workerThreadExecutionService != null) {
             return _workerThreadExecutionService;
         }
 
-        ThreadPoolConfig workerPoolConfig = getWorkerPoolCfg(_ioStrategy);
+        ThreadPoolConfig workerPoolConfig = getWorkerPoolCfg(_ioStrategy, _serviceName);
         return new FixedThreadPool(workerPoolConfig);
     }
 


### PR DESCRIPTION
can now do this:

```java
nfsSvc = new OncRpcSvcBuilder()
                    .withPort(this.port)
                    .withTCP()
                    .withAutoPublish()
                    .withWorkerThreadIoStrategy()
                    .withServiceName("bob")
                    .build();
```

and have threads called "bob worker" and "bob SelectorRunner", which is useful when youre running multiple servers in the same process.
