### PR TITLE
support large constants, plus some changes to tests to work properly on windows

### DIFF
--- a/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/AsyncBlobStoreTest.java
+++ b/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/AsyncBlobStoreTest.java
@@ -1,7 +1,10 @@
 package org.dcache.oncrpc4j.rpcgen;
 
 import org.dcache.xdr.RpcAuthTypeNone;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Radai Rosenblatt
@@ -16,6 +19,7 @@ public class AsyncBlobStoreTest extends AbstractBlobStoreTest {
         Value v = new Value();
         v.notNull = true;
         v.data = blob;
+        serverImpl.setSleepFor(0);
         int size = 150000;
         RpcAuthTypeNone auth = new RpcAuthTypeNone();
         int issued = 0;
@@ -29,5 +33,13 @@ public class AsyncBlobStoreTest extends AbstractBlobStoreTest {
         } finally {
             System.err.println("issued " + issued + " collected " + collected);
         }
+        long timeout = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1L);
+        while (System.currentTimeMillis() < timeout) {
+            Thread.sleep(100);
+            if (serverImpl.getNumRequestsProcessed() >= size) {
+                break;
+            }
+        }
+        Assert.assertTrue("not all requests sent were processed within the timeout", serverImpl.getNumRequestsProcessed() >= size);
     }
 }

--- a/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/BigConstsGenerationTest.java
+++ b/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/BigConstsGenerationTest.java
@@ -1,0 +1,23 @@
+package org.dcache.oncrpc4j.rpcgen;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigInteger;
+
+/**
+ * Created by Radai Rosenblatt
+ */
+public class BigConstsGenerationTest {
+    @Test
+    public void testBigCostsGeneration() throws Exception{
+        //small is within int range
+        Assert.assertTrue(Calculator.SMALL_CONST <= Integer.MAX_VALUE);
+        Assert.assertTrue(Calculator.SMALL_CONST >= Integer.MIN_VALUE);
+        //large is a long above max int
+        Assert.assertTrue(Calculator.LARGE_CONST >= Integer.MAX_VALUE);
+        Assert.assertTrue(Calculator.LARGE_CONST <= Long.MAX_VALUE);
+        //huge us a bigint beyond max long
+        Assert.assertTrue(Calculator.HUGE_CONST.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0);
+    }
+}

--- a/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/LeakTest.java
+++ b/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/LeakTest.java
@@ -2,12 +2,22 @@ package org.dcache.oncrpc4j.rpcgen;
 
 import com.google.common.base.Throwables;
 import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.net.ConnectException;
 import java.net.InetAddress;
+import java.util.Locale;
 
 public class LeakTest {
+
+    @Before
+    public void checkForWindows() {
+        String osName = System.getProperty("os.name");
+        //the test below runs unreasonably slow on windows
+        Assume.assumeTrue(osName != null && !osName.toLowerCase(Locale.ROOT).contains("windows"));
+    }
 
     @Test
     public void testLeakOnConnectionRefused() throws Throwable {

--- a/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/SyncBlobStoreTest.java
+++ b/oncrpc4j-rpcgen/src/test/java/org/dcache/oncrpc4j/rpcgen/SyncBlobStoreTest.java
@@ -25,6 +25,6 @@ public class SyncBlobStoreTest extends AbstractBlobStoreTest {
         Key key = new Key();
         key.setData(new byte[]{1,2,3});
         Value returned = client.get_1(key, 0, null, null);
-        int g = 8;
+        Assert.assertFalse(returned.notNull);
     }
 }

--- a/oncrpc4j-rpcgen/src/test/xdr/Calculator.x
+++ b/oncrpc4j-rpcgen/src/test/xdr/Calculator.x
@@ -1,3 +1,7 @@
+const SMALL_CONST = 0xFF00;
+const LARGE_CONST = 0xFFF000000000;
+const HUGE_CONST  = 0xFFF000000000000000000;
+
 struct CalculationResult {
     hyper  result;
     unsigned hyper startMillis;


### PR DESCRIPTION
the big change here is that now XDR of the form:

const SMALL_CONST = 0xFF00;

const LARGE_CONST = 0xFFF000000000;

const HUGE_CONST  = 0xFFF000000000000000000;

is translated into:


public static final int SMALL_CONST = 0xFF00;

public static final long LARGE_CONST = 0xFFF000000000L;

public static final BigInteger HUGE_CONST = new BigInteger("FFF000000000000000000", 16);

i also cleaned up some tests and disabled the mem leak test on windows as it takes ages to run (socket failures are slow on windows)
