### PR TITLE
fix grizzly utils to adhere to grizzly minimum selector pool size (#cpus + 1)

### DIFF
--- a/oncrpc4j-core/src/main/java/org/dcache/xdr/GrizzlyUtils.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/xdr/GrizzlyUtils.java
@@ -74,8 +74,7 @@ public class GrizzlyUtils {
     }
 
     static private int getSelectorPoolSize(IoStrategy ioStrategy) {
-        return ioStrategy == WORKER_THREAD
-                ? Math.max(MIN_SELECTORS, CPUS / 4) : Math.max(MIN_WORKERS, CPUS);
+        return Runtime.getRuntime().availableProcessors() + 1; //see TCPNIOTransport.getDefaultSelectorRunnersCount()
     }
 
     static private int getWorkerPoolSize(IoStrategy ioStrategy) {


### PR DESCRIPTION
if you look in org.glassfish.grizzly.nio.NIOTransport.start() at line 458 you'll see this:

```java
} else if (kernelPoolConfig.getMaxPoolSize() < selectorRunnersCnt) {
    LOGGER.log(Level.INFO, "Adjusting kernel thread pool to max "
        + "size {0} to handle configured number of SelectorRunners",
        selectorRunnersCnt);
    kernelPoolConfig.setCorePoolSize(selectorRunnersCnt)
        .setMaxPoolSize(selectorRunnersCnt);
}
```

with the value for `selectorRunnersCnt` for TcpNioTransport coming from:

```java
    @Override
    protected int getDefaultSelectorRunnersCount() {
        // Consider ACCEPTOR will occupy one selector thread, and depending
        // on usecase it might be idle for most of the time -
        // so allocate one more extra thread to process channel events
        return Runtime.getRuntime().availableProcessors() + 1;
    }
```

that means that anything under #cpus + 1 is overridden and an annoying message printed.
i've fixed the util class to match grizzly