### PR TITLE
oncrpc4j-portmapdaemon - an executable jar wrapper for oncrpc's portmap server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.iml
 target
+dependency-reduced-pom.xml

--- a/oncrpc4j-portmapdaemon/pom.xml
+++ b/oncrpc4j-portmapdaemon/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dcache</groupId>
+        <artifactId>oncrpc4j</artifactId>
+        <version>2.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oncrpc4j-portmapdaemon</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.dcache.jarpcbind.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.dcache</groupId>
+            <artifactId>oncrpc4j-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/oncrpc4j-portmapdaemon/src/main/java/org/dcache/jarpcbind/Main.java
+++ b/oncrpc4j-portmapdaemon/src/main/java/org/dcache/jarpcbind/Main.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2009 - 2016 Deutsches Elektronen-Synchroton,
+ * Member of the Helmholtz Association, (DESY), HAMBURG, GERMANY
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program (see the file COPYING.LIB for more
+ * details); if not, write to the Free Software Foundation, Inc.,
+ * 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+package org.dcache.jarpcbind;
+
+import org.dcache.xdr.OncRpcProgram;
+import org.dcache.xdr.OncRpcSvc;
+import org.dcache.xdr.OncRpcSvcBuilder;
+import org.dcache.xdr.RpcDispatchable;
+import org.dcache.xdr.portmap.OncRpcPortmap;
+import org.dcache.xdr.portmap.OncRpcbindServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Main {
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
+    private static final Object LOCK = new Object();
+    private static volatile boolean on = true;
+    private static volatile Thread mainThread;
+
+    public static void main(String[] args) throws Exception {
+        mainThread = Thread.currentThread();
+        logger.info("starting up");
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                logger.info("interrupt received, shutting down");
+                synchronized (LOCK) {
+                    on = false;
+                    LOCK.notifyAll();
+                    mainThread.interrupt();
+                }
+                try {
+                    mainThread.join();
+                } catch (InterruptedException e) {
+                    logger.error("interrupted waiting for graceful shutdown", e);
+                }
+                logger.info("exiting");
+            }
+        });
+        RpcDispatchable rpcbind = new OncRpcbindServer();
+        OncRpcSvc server  = new OncRpcSvcBuilder()
+                .withPort(OncRpcPortmap.PORTMAP_PORT)
+                .withTCP()
+                .withUDP()
+                .withSameThreadIoStrategy()
+                .withoutAutoPublish()
+                .build();
+        server.register(new OncRpcProgram(OncRpcPortmap.PORTMAP_PROGRAMM, OncRpcPortmap.PORTMAP_V2), rpcbind);
+        server.start();
+        logger.info("up and running");
+        synchronized (LOCK) {
+            while (on) {
+                try {
+                    LOCK.wait();
+                } catch (InterruptedException e) {
+                    if (on) {
+                        logger.error("spurious interruption", e);
+                    }
+                }
+            }
+        }
+        logger.info("shutting down");
+    }
+}

--- a/oncrpc4j-portmapdaemon/src/main/resources/logback.xml
+++ b/oncrpc4j-portmapdaemon/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
       <module>oncrpc4j-core</module>
       <module>oncrpc4j-spring</module>
       <module>oncrpc4j-rpcgen</module>
+      <module>oncrpc4j-portmapdaemon</module>
   </modules>
 
   <build>
@@ -162,6 +163,11 @@
               <groupId>org.slf4j</groupId>
               <artifactId>slf4j-api</artifactId>
               <version>1.7.5</version>
+          </dependency>
+          <dependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-classic</artifactId>
+              <version>1.1.0</version> <!-- must match slf4j-api ver -->
           </dependency>
           <dependency>
               <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Signed-off-by: radai-rosenblatt <radai.rosenblatt@gmail.com>

basically an executable fat-jar to enable running portmap on operating systems that lack a functioning rpcbind (mac and *gasp* windows :-) )
you launch it as
`sudo java -jar ./jarpcbind-2.6.0-SNAPSHOT.jar`
and it will run and log to stdout until you hit ctrl-c

service bindings for osx to follow shortly