### PR TITLE
fixed stack overflow for recursive constant definitions

### DIFF
--- a/oncrpc4j-rpcgen/src/main/java/org/acplt/oncrpc/apps/jrpcgen/JrpcgenConst.java
+++ b/oncrpc4j-rpcgen/src/main/java/org/acplt/oncrpc/apps/jrpcgen/JrpcgenConst.java
@@ -79,7 +79,7 @@ public class JrpcgenConst {
             // look it up in the list of global identifiers. Then recursively
             // resolve the value.
             //
-            Object id = jrpcgen.globalIdentifiers.get(identifier);
+            Object id = jrpcgen.globalIdentifiers.get(value);
             if ( (id != null)
                  && (id instanceof JrpcgenConst) ) {
                 return ((JrpcgenConst) id).resolveValue();


### PR DESCRIPTION
Hi,

Thanks for oncrpc4j. This project saved me a lot of time and headaches. For my RPC client app, I started to build a JNI wrapper for the .c files but using this project was very easy to use and integrate.

I noticed when I used the rpcgen project to generate source, that I was getting a stackoverflow error. My one line change fixed the issue.

        Developer's Certificate of Origin 1.1

        By making a contribution to this project, I certify that:

        (a) The contribution was created in whole or in part by me and I
            have the right to submit it under the open source license
            indicated in the file; or

        (b) The contribution is based upon previous work that, to the best
            of my knowledge, is covered under an appropriate open source
            license and I have the right under that license to submit that
            work with modifications, whether created in whole or in part
            by me, under the same open source license (unless I am
            permitted to submit under a different license), as indicated
            in the file; or

        (c) The contribution was provided directly to me by some other
            person who certified (a), (b) or (c) and I have not modified
            it.

	(d) I understand and agree that this project and the contribution
	    are public and that a record of the contribution (including all
	    personal information I submit with it, including my sign-off) is
	    maintained indefinitely and may be redistributed consistent with
	    this project or the open source license(s) involved.

Signed-off-by: Tim Stoner <timothy.m.stoner@gmail.com>
