### PR TITLE
Remove unnecessary null check in generated code

### DIFF
--- a/oncrpc4j-rpcgen/src/main/java/org/acplt/oncrpc/apps/jrpcgen/jrpcgen.java
+++ b/oncrpc4j-rpcgen/src/main/java/org/acplt/oncrpc/apps/jrpcgen/jrpcgen.java
@@ -1111,7 +1111,7 @@ public class jrpcgen {
             //
             for (int size = s.elements.size(); size > 1; --size) {
                 decl = (JrpcgenDeclaration) decls.nextElement();
-                out.print("    if( $this." + decl.identifier + " != null)  " + codingMethod(decl, true, "$this"));
+                out.print("    " + codingMethod(decl, true, "$this"));
             }
             decl = (JrpcgenDeclaration) decls.nextElement();
             out.println("            $this = $this." + decl.identifier + ";");


### PR DESCRIPTION
jrpcgen currently generates unwanted null checks when the iterative linked list encoding approach is used. This causes compile errors in the generated code for fields with primitive types. As an example

For Entry3 from the NFSv3 spec

```
struct Entry3 {
    unsigned hyper      fileid;
    string    name<>;
    unsigned hyper      cookie;
    Entry3       *nextentry;
};
```

jrpcgen currently generates

```
public long fileid;
public String name;
public long cookie;
public Entry3 nextentry;

public void xdrEncode(XdrEncodingStream xdr) throws OncRpcException, IOException {
    Entry3 $this = this;
    do {
        if( $this.fileid != null) xdr.xdrEncodeLong($this.fileid);
        if( $this.name != null) xdr.xdrEncodeString($this.name);
        if( $this.cookie != null) xdr.xdrEncodeLong($this.cookie);
        $this = $this.nextentry;
        xdr.xdrEncodeBoolean($this != null);
    } while ( $this != null );
}
```

This PR removes those null checks. As far as I can tell, `codingMethod` can be used without the additional check since it already generates code that deals with null values.