### PR TITLE
Add xdr(encode|decode)(Int|Long)FixedVector

### DIFF
--- a/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/xdr/Xdr.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/xdr/Xdr.java
@@ -152,6 +152,23 @@ public class Xdr implements XdrDecodingStream, XdrEncodingStream, AutoCloseable 
     }
 
     /**
+     * Decodes (aka "deserializes") a vector of ints read from a XDR stream.
+     *
+     * @param length of vector to read.
+     *
+     * @return Decoded int vector.
+     * @throws BadXdrOncRpcException if xdr stream can't be decoded.
+     */
+    @Override
+    public int[] xdrDecodeIntFixedVector(int length) throws BadXdrOncRpcException {
+        int[] value = new int[length];
+        for (int i = 0; i < length; ++i) {
+            value[i] = xdrDecodeInt();
+        }
+        return value;
+    }
+
+    /**
      * Get next array of long.
      *
      * @return the array on integers
@@ -167,6 +184,23 @@ public class Xdr implements XdrDecodingStream, XdrEncodingStream, AutoCloseable 
             longs[i] = xdrDecodeLong();
         }
         return longs;
+    }
+
+    /**
+     * Decodes (aka "deserializes") a vector of longs read from a XDR stream.
+     *
+     * @param length of vector to read.
+     *
+     * @return Decoded long vector.
+     * @throws BadXdrOncRpcException if xdr stream can't be decoded.
+     */
+    @Override
+    public long[] xdrDecodeLongFixedVector(int length) throws BadXdrOncRpcException {
+        long[] value = new long[length];
+        for (int i = 0; i < length; ++i) {
+            value[i] = xdrDecodeLong();
+        }
+        return value;
     }
 
     /**
@@ -491,6 +525,24 @@ public class Xdr implements XdrDecodingStream, XdrEncodingStream, AutoCloseable 
     }
 
     /**
+     * Encodes (aka "serializes") a vector of ints and writes it down this XDR
+     * stream.
+     *
+     * @param value int vector to be encoded.
+     * @param length of vector to write. This parameter is used as a sanity
+     * check.
+     */
+    @Override
+    public void xdrEncodeIntFixedVector(int[] value, int length) {
+        if (value.length != length) {
+            throw (new IllegalArgumentException("array size does not match protocol specification"));
+        }
+        for (int i = 0; i < length; i++) {
+            xdrEncodeInt(value[i]);
+        }
+    }
+
+    /**
      * Encodes (aka "serializes") a vector of longs and writes it down
      * this XDR stream.
      *
@@ -506,6 +558,24 @@ public class Xdr implements XdrDecodingStream, XdrEncodingStream, AutoCloseable 
         }
     }
 
+    /**
+     * Encodes (aka "serializes") a vector of longs and writes it down this XDR
+     * stream.
+     *
+     * @param value long vector to be encoded.
+     * @param length of vector to write. This parameter is used as a sanity
+     * check.
+     */
+    @Override
+    public void xdrEncodeLongFixedVector(long[] value, int length) {
+        if (value.length != length) {
+            throw (new IllegalArgumentException("array size does not match protocol specification"));
+        }
+        for (int i = 0; i < length; i++) {
+            xdrEncodeLong(value[i]);
+        }
+    }
+    
     /**
      * Encodes (aka "serializes") a float (which is a 32 bits wide floating
      * point quantity) and write it down this XDR stream.

--- a/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/xdr/XdrDecodingStream.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/xdr/XdrDecodingStream.java
@@ -34,6 +34,7 @@ public interface XdrDecodingStream {
     void endDecoding();
     int xdrDecodeInt() throws BadXdrOncRpcException;
     int[] xdrDecodeIntVector() throws BadXdrOncRpcException;
+    int[] xdrDecodeIntFixedVector(int len) throws BadXdrOncRpcException;
     byte[] xdrDecodeDynamicOpaque() throws BadXdrOncRpcException;
     byte[] xdrDecodeOpaque(int size) throws BadXdrOncRpcException;
     void xdrDecodeOpaque(byte[] data, int offset, int len) throws BadXdrOncRpcException;
@@ -41,6 +42,7 @@ public interface XdrDecodingStream {
     String xdrDecodeString() throws BadXdrOncRpcException;
     long xdrDecodeLong() throws BadXdrOncRpcException;
     long[] xdrDecodeLongVector() throws BadXdrOncRpcException;
+    long[] xdrDecodeLongFixedVector(int len) throws BadXdrOncRpcException;
     ByteBuffer xdrDecodeByteBuffer() throws BadXdrOncRpcException;
     float xdrDecodeFloat() throws BadXdrOncRpcException;
     double xdrDecodeDouble() throws BadXdrOncRpcException;

--- a/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/xdr/XdrEncodingStream.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/xdr/XdrEncodingStream.java
@@ -33,6 +33,7 @@ public interface XdrEncodingStream {
     void endEncoding();
     void xdrEncodeInt(int value);
     void xdrEncodeIntVector(int[] ints);
+    void xdrEncodeIntFixedVector(int[] ints, int length);
     void xdrEncodeDynamicOpaque(byte [] opaque);
     void xdrEncodeOpaque(byte [] opaque, int len);
     void xdrEncodeOpaque(byte [] opaque, int offset, int len);
@@ -40,6 +41,7 @@ public interface XdrEncodingStream {
     void xdrEncodeString(String str);
     void xdrEncodeLong(long value);
     void xdrEncodeLongVector(long[] longs);
+    void xdrEncodeLongFixedVector(long[] longs, int length);
     void xdrEncodeByteBuffer(ByteBuffer buf);
     void xdrEncodeFloat(float value);
     void xdrEncodeDouble(double value);


### PR DESCRIPTION
Add fixed vector encoding/decoding methods for int and long.
jrpcgen assumes these are available. when processing the rpcbind IDL file the generated code does not compile due to these methods not being present.