### PR TITLE
Allow XdrAble to create it's own Xdr instance

### DIFF
--- a/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/xdr/XdrAble.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/xdr/XdrAble.java
@@ -40,6 +40,21 @@ public interface XdrAble {
     public void xdrDecode(XdrDecodingStream xdr) throws OncRpcException, IOException;
 
     /**
+     * Encodes -- that is: serializes -- an object into a XDR object in
+     * compliance to RFC 1832.
+     *
+     * @return the XDR representation of this object.
+     * @throws OncRpcException if an ONC/RPC error occurs.
+     */
+    public default Xdr xdrEncode() throws OncRpcException, IOException {
+        Xdr xdr = new Xdr(Xdr.INITIAL_XDR_SIZE);
+        xdr.beginEncoding();
+        xdrEncode(xdr);
+        xdr.endEncoding();
+        return xdr;
+    }
+
+    /**
      * Encodes -- that is: serializes -- an object into a XDR stream in
      * compliance to RFC 1832.
      *


### PR DESCRIPTION
I ran into performance issues when generating large NFSv3 write requests. The data I want to send is already available in a ByteBuffer and I want to avoid having to copy the entire buffer.

This PR allows XdrAble implementations to optionally create an Xdr instance themselves. This enable gather-style writes where the final Xdr wraps a composite Grizzly buffer. For instance, in my prototype version of this PR, the nfs Write3Args is creating an Xdr wrapper around a composite buffer consisting of `<write3args header><data buffer><padding buffer>`. This improved write performance quite a bit.

Note that this PR is mainly to get a discussion started; there might be better ways to provide this functionality. This is just a first draft.