### PR TITLE
Expose startTLS in generated stubs.

### DIFF
--- a/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/rpc/OncRpcClient.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/rpc/OncRpcClient.java
@@ -19,6 +19,10 @@
  */
 package org.dcache.oncrpc4j.rpc;
 
+import com.google.common.annotations.Beta;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -163,6 +167,28 @@ public class OncRpcClient implements AutoCloseable {
 
         public OncRpcClientBuilder withTcpNoDelay(boolean tcpNoDelay) {
             svcBuilder.withTcpNoDelay(tcpNoDelay);
+            return this;
+        }
+
+        public OncRpcClientBuilder withSSLContext(SSLContext sslContext) {
+            svcBuilder.withSSLContext(sslContext);
+            return this;
+        }
+
+        public OncRpcClientBuilder withSSLParameters(SSLParameters sslParams) {
+            svcBuilder.withSSLParameters(sslParams);
+            return this;
+        }
+
+        @Beta
+        public OncRpcClientBuilder withStartTLS() {
+            svcBuilder.withStartTLS();
+            return this;
+        }
+
+        @Beta
+        public OncRpcClientBuilder withoutStartTLS() {
+            svcBuilder.withoutStartTLS();
             return this;
         }
 

--- a/oncrpc4j-rpcgen/src/main/java/org/acplt/oncrpc/apps/jrpcgen/jrpcgen.java
+++ b/oncrpc4j-rpcgen/src/main/java/org/acplt/oncrpc/apps/jrpcgen/jrpcgen.java
@@ -1924,6 +1924,7 @@ public class jrpcgen {
 
         out.println("import java.io.Closeable;");
         out.println("import java.net.InetAddress;");
+        out.println("import java.util.concurrent.atomic.AtomicBoolean;");
         if (generateAsyncFutureClient) {
             out.println("import java.util.concurrent.Future;");
         }
@@ -1951,6 +1952,7 @@ public class jrpcgen {
         // generated class fields
         out.println("    private final OncRpcClient rpcClient;");
         out.println("    private final RpcCall client;");
+        out.println("    private final AtomicBoolean tlsStarted = new AtomicBoolean();");
         out.println();
 
         //
@@ -2058,6 +2060,16 @@ public class jrpcgen {
         out.println("            rpcClient.close();");
         out.println("            throw e;");
         out.println("        } ");
+        out.println("    }");
+        out.println();
+
+        out.println("    /**");
+        out.println("     * Upgrades the underlying transport to TLS using STARTTLS mechanism.");
+        out.println("     */");
+        out.println("    public void startTLS() throws IOException {");
+        out.println("        if (tlsStarted.compareAndSet(false, true)) {");
+        out.println("            client.startTLS();");
+        out.println("        }");
         out.println("    }");
         out.println();
 


### PR DESCRIPTION
This feature is to expose existing (beta) startTLS functionality in generated client stubs by:

1. adding with SSL options to the client builder and
2. enhancing the stug generator (jrpcgen) to make it possible to upgrade an existing client from plaintext to tls.
