### PR TITLE
core: Don't duplicate Buffers when not necessary

### DIFF
--- a/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/xdr/Xdr.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/xdr/Xdr.java
@@ -923,8 +923,9 @@ public class Xdr implements XdrDecodingStream, XdrEncodingStream, AutoCloseable 
         checkState(!_inUse, "getBytes called while buffer in use");
         int size = _buffer.remaining();
         byte[] bytes = new byte[size];
-        Buffer dup = _buffer.duplicate();
-        dup.get(bytes);
+        _buffer.mark();
+        _buffer.get(bytes);
+        _buffer.reset();
         return bytes;
     }
 


### PR DESCRIPTION
We're currently duplicate()-ing Buffers in two instances where we read-ahead some data, so we don't have to revert to the old position afterwards.

While it's a somewhat simple operation for regular HeapByteBuffers, Buffer#duplicate() is not a free operation. Unfortunately, especially with Grizzly's BuffersBuffer (or other implementations that we may use), its use needs to be justified.

Replace the two instances with code that keeps track of the original position before the read-access, reverting back to it afterwards, without requiring new buffer allocations.

Also remove an explicit byteOrder(BIG_ENDIAN) call; all our buffers are BIG_ENDIAN, just like the default.