### PR TITLE
Specify client connect timeout in OncRpcClientBuilder; consume in OncRpcClient connect call.

### DIFF
--- a/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/rpc/OncRpcClient.java
+++ b/oncrpc4j-core/src/main/java/org/dcache/oncrpc4j/rpc/OncRpcClient.java
@@ -34,6 +34,8 @@ public class OncRpcClient implements AutoCloseable {
     private static final String DEFAULT_SERVICE_NAME = null;
 
     private final InetSocketAddress _socketAddress;
+    private final long _connectTimeout;
+    private final TimeUnit _connectTimeoutUnit;
     private final OncRpcSvc _rpcsvc;
 
     public OncRpcClient(InetAddress address, int protocol, int port) {
@@ -66,14 +68,19 @@ public class OncRpcClient implements AutoCloseable {
                 .build());
     }
 
-
     private OncRpcClient(InetSocketAddress socketAddress, OncRpcSvc clientSvc) {
+        this(socketAddress, Long.MAX_VALUE, TimeUnit.MILLISECONDS, clientSvc);
+    }
+
+    public OncRpcClient(InetSocketAddress socketAddress, long connectTimeout, TimeUnit connectTimeoutUnit, OncRpcSvc clientSvc) {
         _socketAddress = socketAddress;
+        _connectTimeout = connectTimeout;
+        _connectTimeoutUnit = connectTimeoutUnit;
         _rpcsvc = clientSvc;
     }
 
     public RpcTransport connect() throws IOException {
-        return connect(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        return connect(_connectTimeout, _connectTimeoutUnit);
     }
 
     public RpcTransport connect(long timeout, TimeUnit timeUnit) throws IOException {
@@ -105,6 +112,8 @@ public class OncRpcClient implements AutoCloseable {
                 .withSelectorThreadPoolSize(1)
                 .withWorkerThreadPoolSize(1)
                 .withoutAutoPublish();
+        private long connectTimeout = Long.MAX_VALUE;
+        private TimeUnit connectTimeoutUnit = TimeUnit.MILLISECONDS;
 
         private OncRpcClientBuilder() {
             // no direct instantiation
@@ -192,6 +201,12 @@ public class OncRpcClient implements AutoCloseable {
             return this;
         }
 
+        public OncRpcClientBuilder withConnectTimeout(long timeout, TimeUnit unit) {
+            this.connectTimeout = timeout;
+            this.connectTimeoutUnit = unit;
+            return this;
+        }
+
         /**
          * Build a new {@link OncRpcClient} instance.
          *
@@ -199,7 +214,7 @@ public class OncRpcClient implements AutoCloseable {
          * @return a new {@link OncRpcClient} instance
          */
         public OncRpcClient build(InetSocketAddress endpoint) {
-            return new OncRpcClient(endpoint, svcBuilder.build());
+            return new OncRpcClient(endpoint, connectTimeout, connectTimeoutUnit, svcBuilder.build());
         }
 
         /**


### PR DESCRIPTION
This change adds a withConnectTimeout method to the OncRpcClientBuilder, which populates two fields:
```
long connectTimeout;
TimeUnit connectTimeoutUnit;
```

These fields are then passed into the OncRpcClient during build and stored there as final fields on the OncRpcClient. When connect() is called, these values are used. They default to the same values that connect() originally used - Long.MAX_VALUE, and TimeUnit.MILLISECONDS.

This change allows generated interfaces to use a user-specified connect timeout, defaulting to the original default values if not specified. Note the rpcgen code did not need to be modified for this, as it continues to use rpcClient.connect(), but internally, this method uses the builder-specified default values, or the original default values if no builder was used. 

An additional constructor is added to facilitate passing the default connect timeout parameters, which makes it possible for non-builder-users to also specify the default connect timeout (though they may also pass those values to connect directly).

This change should be 100% backward compatible. Please also merge to 3.3, if you have nothing against doing so.

Signed-off-by: John Calcote <john.calcote@gmail.com>